### PR TITLE
Fixed Game Grid transparency for Buttons

### DIFF
--- a/Resource/layout/gamespage_grid.layout
+++ b/Resource/layout/gamespage_grid.layout
@@ -31,7 +31,7 @@
 
 		GameItem_unInstalled
 		{
-			alpha		120
+			alpha		255
 		}
 
 		GameItem_Updating

--- a/Resource/styles/steam.styles
+++ b/Resource/styles/steam.styles
@@ -61,6 +61,17 @@ steam.styles
 
 	styles
 	{
+
+		"GameItem_Uninstalled GGPlaceholderBG" 
+		{
+			alpha 120
+		}
+
+		"GameItem_Uninstalled GamesGridImage" 
+		{
+			alpha 120
+		}
+
 		"COverlaySettingsDialog Page" {
 			inset-left=10
 			inset-top=10

--- a/Steam/cached/SettingsSubInterface.res
+++ b/Steam/cached/SettingsSubInterface.res
@@ -15,7 +15,8 @@
 			dir=down start=SkinCombo y=20
 		}
 
-		place { control=NotifyAvailableGamesCheck		dir=down start=H264HWAccelCheck y=4 }
+		place [$LINUX||$OSX] { control=NotifyAvailableGamesCheck		dir=down start=UrlBarCheck y=4 }
+		place [$WINDOWS] { control=NotifyAvailableGamesCheck		dir=down start=H264HWAccelCheck y=4 }
 
 		place { control=SetJumpListOptionsButton		dir=down start=NotifyAvailableGamesCheck y=10 }
 


### PR DESCRIPTION
Changed the method for applying transparency to the Game Grid uninstalled items. The old way meant that any children elements (Install Button) would also be transparent. This new commit makes the children elements full opacity while the background image stays transparent.