### PR TITLE
Added Purple As A New Color

### DIFF
--- a/Resource/colors/purple.styles
+++ b/Resource/colors/purple.styles
@@ -1,0 +1,9 @@
+"" {
+
+	colors {
+		Focus="102 51 153 255"		//dark purple main color
+		Focus2="126 72 181 255"	//lighter purple for headers
+		Focus3="126 72 181 150"	//lighter purple with opacity for content boxes
+		Focus4="102 0 153 255"		//darker purple for contrast 
+	}
+}


### PR DESCRIPTION
Added a custom purple style. The themes lacked a true deep purple color, so I've quickly added one in based on my previous edits for Air legacy... Tested and working without any issues. Optionally can be called "darkpurple" as it is darker than actual purple (of which there are many variations).