### PR TITLE
Added Purple Support

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -43,7 +43,7 @@ config.ini {
 			//include "resource/colors/cinnabar.styles"
 			//include "resource/colors/lavender.styles"
 			//include "resource/colors/lilac.styles"
-
+			//include "resource/colors/purple.styles"
 			//User contributed themes
 			//include "resource/colors/user/numix.styles" //Contributed by Markus-Deviant (markus-deviant.deviantart.com), Numix Project by Satyajit (satya164.deviantart.com)
 


### PR DESCRIPTION
Added reference to a custom purple style. The themes lacked a true deep purple color, so I've quickly added one in based on my previous edits for Air legacy... Tested and working without any issues. Optionally can be called "darkpurple" as it is darker than actual purple (of which there are many variations).