### PR TITLE
New Downloads Page Fix

### DIFF
--- a/Resource/layout/appdownloadpanel.layout
+++ b/Resource/layout/appdownloadpanel.layout
@@ -83,6 +83,7 @@
 		place { control=downloadtotallabel,downloadtotalfield region=column3 spacing=20 y=21 height=19 }
 		place { control=timecompletedlabel,timecompletedfield,starttimelabel,starttimefield region=column3 spacing=20 y=51 height=19 }
 		place { control=timeremaininglabel,timeremainingfield region=column3 spacing=20 y=81 height=19 }
+		place { control=pausereasonlabel,pausereasonfield   region=column3 spacing=47 y=70 }
 
 		place { control=topofqueuebutton region=column3 y=18 align=right height=24 width=24 }
 		place { control=removefromqueuebutton region=column3 y=48 align=right height=24 width=24 }

--- a/Resource/layout/downloadsummarypanel.layout
+++ b/Resource/layout/downloadsummarypanel.layout
@@ -6,10 +6,30 @@
 			render_bg { }
 		}
 
-		GraphPanel {
-			textcolor=AL100 // graph bars color
+		NetGraphPanel {
+			textcolor=AL100 // download graph bars color
 			bgcolor=none
 			inset-left=1
+		}
+		
+		DiscGraphPanel {
+			textcolor=AL250 // disk usage color
+			bgcolor=none
+			inset-left=1
+		}
+		
+		DiskLegendPanel	{
+			render_bg {
+				// background fill
+				0="fill( x0, y0, x1,y1, AL250 )"
+			}
+		}
+		
+		NetLegendPanel	{
+			render_bg {
+				// background fill
+				0="fill( x0, y0, x1,y1, AL100 )"
+			}
 		}
 	}
 
@@ -17,18 +37,27 @@
 
 		region { name=notification height=50 width=max }
 		region { name=graph y=50 height=80 width=max }
+		region { name=legend align=right width=200 margin-top=12 }
 
-		place { control="GraphPanel" region=graph width=max height=max }
+		place { control="net_graphpanel" region=graph width=max height=max }
+		place { control="disc_graphpanel" region=graph width=max height=max }
+
+		// graph legend
+		place { control="net_legend_panel" region=legend y=3 x=0 width=9 height=9 }
+		place { control="net_legend_label" region=legend y=0 x=12 }
+		
+		place { control="disk_legend_panel" region=legend y=16 x=0  width=9 height=9 }
+		place { control="disk_legend_label" region=legend y=13 x=12 }
 
 		place { control="pauseresumeallbutton" region=notification align=right y=9 margin-right=26 }
 
-		place { region=notification control="download_rate,download_rate_value" 						y=17 x=26 spacing=10 }
+		place { region=notification control="download_rate,download_rate_value" 						y=10 x=26 spacing=10 }
 		place { region=notification control="peak_download_rate,peak_download_rate_value" 	x=20 spacing=10 start=download_rate_value }
 		place { region=notification control="total_downloaded,total_downloaded_value" 			x=20 spacing=10 start=peak_download_rate_value }
-		place { region=notification control="blackout_label,blackout_value" 								x=20 spacing=10 start=total_downloaded_value }
-		place { region=notification control="throttling_label,throttling_value" 						x=20 spacing=10 start=blackout_value }
-		place { region=notification control="disk_status_label" 														x=20 start=throttling_value }
-
+		place { region=notification control="disk_status_label, disk_status_value" 					x=20 spacing=10 start=total_downloaded_value }
+		place { region=notification control="blackout_label,blackout_value" 							y=28 x=26 spacing=10 }
+		place { region=notification control="throttling_label,throttling_value" 							x=20 spacing=10 start=blackout_value }
+		
 		place { control=header height=0 width=0 } //Network label
 	}
 }


### PR DESCRIPTION
This change would fix the issue after the new steam update the broke the downloads page. Made sure to enabling throttling and autodownloads so I could see if they can all fit on the smallest possible window size. Here's a couple screenshots highlighting the changes.

![downloads](https://cloud.githubusercontent.com/assets/11904616/8558073/b6f16a6c-24b6-11e5-8699-1fd8144ffc9d.png)

I also added the "Paused" and "Pause reason" lines in the actual downloads area.

![downloads1](https://cloud.githubusercontent.com/assets/11904616/8558241/ae3c2fdc-24b7-11e5-8ec8-456d1caf9dd8.png)

If the problem hasn't already been resolved, hopefully this can be merged. I'm fairly certain it's not causing any issues either as far as I can tell.